### PR TITLE
fix/terraform version lock

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~>6.2.0"
+      version = ">6.2.0"
     }
     http = {
       source  = "hashicorp/http"
-      version = "3.4.2"
+      version = ">3.4.2"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~>1.7.0"
+  required_version = ">1.7.0"
   required_providers {
     github = {
       source  = "integrations/github"


### PR DESCRIPTION
- **removed terraform version constrained, this allows the use of terraform 1.8.0 and later versions**
  

- **removed other version constraints as well - this makes the module most flexible**
  